### PR TITLE
vertex using correct up-to-date kfp imports

### DIFF
--- a/src/compiler.py
+++ b/src/compiler.py
@@ -6,8 +6,7 @@ Supports dev and prod variants of the diabetes prediction pipeline with dynamic 
 import argparse
 import sys
 from typing import Callable
-from kfp.v2 import compiler
-from kfp.dsl import Pipeline
+from kfp import compiler
 
 from vertex_pipeline_dev import dev_diabetes_pipeline
 from vertex_pipeline_prod import prod_diabetes_pipeline
@@ -34,8 +33,6 @@ def main() -> None:
         help="Path to the output compiled YAML file."
     )
     args = parser.parse_args()
-
-    pipeline_func: Callable[..., Pipeline]
 
     # Select pipeline function based on filename
     if "vertex_pipeline_dev.py" in args.py:

--- a/src/vertex_pipeline_dev.py
+++ b/src/vertex_pipeline_dev.py
@@ -6,8 +6,8 @@ Vertex AI KFP Pipeline for Development
 - Conditionally registers the model in Vertex AI Model Registry if accuracy is sufficient
 """
 
-from kfp.v2 import dsl
-from kfp.v2.dsl import (
+from kfp import dsl
+from kfp.dsl import (
     component,
     pipeline,
     Input,

--- a/src/vertex_pipeline_prod.py
+++ b/src/vertex_pipeline_prod.py
@@ -6,8 +6,8 @@ Vertex AI KFP Pipeline for Production
 - Conditionally registers a new version linked to a parent model in Vertex AI Model Registry
 """
 
-from kfp.v2 import dsl
-from kfp.v2.dsl import (
+from kfp import dsl
+from kfp.dsl import (
     component,
     pipeline,
     Input,


### PR DESCRIPTION
Your files are already using the correct, up-to-date KFP imports (from kfp import ... and [from kfp.dsl import ...](vscode-file://vscode-app/c:/Users/david/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)).
You are not using any deprecated [kfp.v2](vscode-file://vscode-app/c:/Users/david/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) imports in the provided code for:

[compiler.py](vscode-file://vscode-app/c:/Users/david/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
[vertex_pipeline_dev.py](vscode-file://vscode-app/c:/Users/david/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
[vertex_pipeline_prod.py](vscode-file://vscode-app/c:/Users/david/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
Review Summary
✅ All pipeline and compiler files use from kfp import ... and [from kfp.dsl import ...](vscode-file://vscode-app/c:/Users/david/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html).
✅ No deprecated [from kfp.v2 import ...](vscode-file://vscode-app/c:/Users/david/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) or [from kfp.v2.dsl import ...](vscode-file://vscode-app/c:/Users/david/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) found.
✅ This is compatible with current and future KFP SDK versions.