### PR TITLE
vertex Replace all eval_task.output with eval_task.outputs[output] 

### DIFF
--- a/src/vertex_pipeline_dev.py
+++ b/src/vertex_pipeline_dev.py
@@ -237,7 +237,7 @@ def dev_diabetes_pipeline(
     )
 
     with dsl.If(
-        eval_task.output >= min_accuracy,
+        eval_task.outputs["output"] >= min_accuracy,
         name="pass-accuracy-threshold"
     ):
         approved = model_approved_op()
@@ -250,10 +250,10 @@ def dev_diabetes_pipeline(
         ).after(approved)
 
     with dsl.If(
-        eval_task.output < min_accuracy,
+        eval_task.outputs["output"] < min_accuracy,
         name="fail-accuracy-threshold"
     ):
         model_rejected_op(
-            model_accuracy=eval_task.output,
+            model_accuracy=eval_task.outputs["output"],
             min_accuracy=min_accuracy
         )

--- a/src/vertex_pipeline_prod.py
+++ b/src/vertex_pipeline_prod.py
@@ -240,11 +240,11 @@ def prod_diabetes_pipeline(
     )
 
     with dsl.If(
-        eval_task.output >= min_accuracy,
+        eval_task.outputs["output"] >= min_accuracy,
         name="pass-accuracy-threshold"
     ):
         approved = model_approved_op(
-            model_accuracy=eval_task.output,
+            model_accuracy=eval_task.outputs["output"],
             model=train_task.outputs["output_model"]
         )
         register_model_op(
@@ -256,10 +256,10 @@ def prod_diabetes_pipeline(
         ).after(approved)
 
     with dsl.If(
-        eval_task.output < min_accuracy,
+        eval_task.outputs["output"] < min_accuracy,
         name="fail-accuracy-threshold"
     ):
         model_rejected_op(
-            model_accuracy=eval_task.output,
+            model_accuracy=eval_task.outputs["output"],
             min_accuracy=min_accuracy
         )


### PR DESCRIPTION
Replace in both pipeline files.
This change is required for correct referencing of outputs from components with multiple outputs.
Your storage input/output paths are handled correctly and are not affected by this change.